### PR TITLE
Add windows to CFFI

### DIFF
--- a/src/low-level/bearlibterminal.lisp
+++ b/src/low-level/bearlibterminal.lisp
@@ -13,7 +13,9 @@
                "lib/libBearLibTerminal.so"))
   (:darwin (:or "Contents/Resources/libBearLibTerminal.dylib"
                 "libBearLibTerminal.dylib"
-                "lib/libBearLibTerminal.dylib")))
+                "lib/libBearLibTerminal.dylib"))
+  (:windows (:or "lib/BearLibTerminal.dll"
+                 "lib/BearLibTerminal.lib")))
 
 (cffi:use-foreign-library blt:bearlibterminal)
 


### PR DESCRIPTION
This adds a windows clause to the CFFI foreign library so that the
library is loaded on windows.